### PR TITLE
Supply air temperature setting

### DIFF
--- a/custom_components/airfi/__init__.py
+++ b/custom_components/airfi/__init__.py
@@ -31,7 +31,12 @@ if TYPE_CHECKING:
 
     from .data import AirfiConfigEntry
 
-PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.FAN, Platform.SENSOR]
+PLATFORMS: list[Platform] = [
+    Platform.BINARY_SENSOR,
+    Platform.FAN,
+    Platform.NUMBER,
+    Platform.SENSOR,
+]
 
 # This integration is configured via config entries only
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)

--- a/custom_components/airfi/coordinator/feature_manager.py
+++ b/custom_components/airfi/coordinator/feature_manager.py
@@ -1,7 +1,7 @@
 """Feature manager for Airfi device detection and validation.
 
 This module provides firmware validation, register length mapping, and device
-capability detection.
+capability detection based on the Modbus map version.
 """
 
 from __future__ import annotations
@@ -32,11 +32,17 @@ class AirfiFeatureManager:
         "1.5.0": (31, 12),
     }
 
+    # Feature flags gated by minimum Modbus map version
+    _FEATURE_VERSION_MAP: dict[str, str] = {
+        "minimum_temperature_set": "2.1.0",
+    }
+
     def __init__(self) -> None:
         """Initialize the feature manager."""
         self.firmware_version = ""
         self.modbus_register_version = ""
         self.hw_version = ""
+        self._feature_flags: dict[str, bool] = dict.fromkeys(self._FEATURE_VERSION_MAP, False)
 
     def initialize(self, device_name: str, lookup_registers: list[int]) -> None:
         """Initialize and validate device based on lookup registers.
@@ -65,6 +71,7 @@ class AirfiFeatureManager:
         self.modbus_register_version = version_string(lookup_registers[2])
 
         self._validate_firmware_version()
+        self._set_feature_flags()
         self._log_device_info(device_name)
 
     def get_register_lengths(self) -> tuple[int, int]:
@@ -137,6 +144,22 @@ class AirfiFeatureManager:
         LOGGER.info("  Firmware version: %s", self.firmware_version)
         LOGGER.info("  Modbus map version: %s", self.modbus_register_version)
         LOGGER.info("-" * len(headline))
+        LOGGER.debug("  Feature flags: %s", self._feature_flags)
+
+    def has_feature(self, feature: str) -> bool:
+        """Check whether the device supports a given feature.
+
+        Args:
+            feature: Feature flag key (e.g. ``"fireplace_function"``).
+
+        """
+        return self._feature_flags.get(feature, False)
+
+    def _set_feature_flags(self) -> None:
+        """Set feature flags based on the Modbus map version."""
+        parsed = version.parse(self.modbus_register_version)
+        for feature, min_ver in self._FEATURE_VERSION_MAP.items():
+            self._feature_flags[feature] = parsed >= version.parse(min_ver)
 
 
 __all__ = ["AirfiFeatureManager"]

--- a/custom_components/airfi/icons.json
+++ b/custom_components/airfi/icons.json
@@ -16,6 +16,11 @@
         }
       }
     },
+    "number": {
+      "supply_air_temperature_setting": {
+        "default": "mdi:home-thermometer"
+      }
+    },
     "sensor": {
       "exhaust_air_temperature": {
         "default": "mdi:thermometer-chevron-up",

--- a/custom_components/airfi/number/__init__.py
+++ b/custom_components/airfi/number/__init__.py
@@ -1,0 +1,32 @@
+"""Number platform for Airfi."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from custom_components.airfi.const import PARALLEL_UPDATES as PARALLEL_UPDATES
+from homeassistant.components.number import NumberEntityDescription
+
+from .temperature import ENTITY_DESCRIPTIONS as TEMPERATURE_DESCRIPTIONS, AirfiTemperatureNumber
+
+if TYPE_CHECKING:
+    from custom_components.airfi.data import AirfiConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+ENTITY_DESCRIPTIONS: tuple[NumberEntityDescription, ...] = (*TEMPERATURE_DESCRIPTIONS,)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: AirfiConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the number platform."""
+    async_add_entities(
+        AirfiTemperatureNumber(
+            coordinator=entry.runtime_data.coordinator,
+            entity_description=entity_description,
+        )
+        for entity_description in TEMPERATURE_DESCRIPTIONS
+    )

--- a/custom_components/airfi/number/temperature.py
+++ b/custom_components/airfi/number/temperature.py
@@ -1,0 +1,57 @@
+"""Supply air temperature number entity for Airfi air handling unit."""
+
+from __future__ import annotations
+
+from custom_components.airfi.entity import AirfiEntity
+from custom_components.airfi.utils.number import (
+    HOLDING_REGISTER_MINIMUM_TEMPERATURE,
+    HOLDING_REGISTER_TARGET_TEMPERATURE,
+)
+from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberEntityDescription, NumberMode
+
+ENTITY_DESCRIPTIONS: tuple[NumberEntityDescription, ...] = (
+    NumberEntityDescription(
+        key="supply_air_temperature_setting",
+        translation_key="supply_air_temperature_setting",
+        device_class=NumberDeviceClass.TEMPERATURE,
+        native_min_value=13.0,
+        native_max_value=25.0,
+        native_step=1.0,
+        mode=NumberMode.BOX,
+    ),
+)
+
+
+class AirfiTemperatureNumber(NumberEntity, AirfiEntity):
+    """Supply air target temperature control.
+
+    Reads/writes holding register 5 (4x00005).
+    Device stores the value as °C × 10 (e.g. 200 = 20.0 °C).
+
+    When the ``minimum_temperature_set`` feature is available (modbus >= 2.1.0),
+    also writes holding register 50 (4x00050) with the raw °C value so the two
+    settings stay in parity.
+    """
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current target temperature in °C."""
+        registers: list[int] = self.coordinator.data.get("holding_registers", [])
+        index = HOLDING_REGISTER_TARGET_TEMPERATURE - 1
+        if index >= len(registers):
+            return None
+        raw = registers[index]
+        return round(raw / 10.0, 1)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the supply air temperature (°C, written as value × 10)."""
+        device_value = int(round(value * 10))
+        await self.coordinator.async_set_holding_register(HOLDING_REGISTER_TARGET_TEMPERATURE, device_value)
+
+        if self.coordinator.feature_manager.has_feature("minimum_temperature_set"):
+            await self.coordinator.async_set_holding_register(
+                HOLDING_REGISTER_MINIMUM_TEMPERATURE,
+                int(round(value)),
+            )
+
+        await self.coordinator.async_request_refresh()

--- a/custom_components/airfi/translations/en.json
+++ b/custom_components/airfi/translations/en.json
@@ -118,6 +118,11 @@
         "name": "Ventilation"
       }
     },
+    "number": {
+      "supply_air_temperature_setting": {
+        "name": "Supply air temperature"
+      }
+    },
     "sensor": {
       "exhaust_air_temperature": {
         "name": "Exhaust air"

--- a/custom_components/airfi/translations/fi.json
+++ b/custom_components/airfi/translations/fi.json
@@ -118,6 +118,11 @@
         "name": "Ilmanvaihto"
       }
     },
+    "number": {
+      "supply_air_temperature_setting": {
+        "name": "Tuloilman lämpötila"
+      }
+    },
     "sensor": {
       "exhaust_air_temperature": {
         "name": "Jäteilma"

--- a/custom_components/airfi/translations/pl.json
+++ b/custom_components/airfi/translations/pl.json
@@ -118,6 +118,11 @@
         "name": "Wentylacja"
       }
     },
+    "number": {
+      "supply_air_temperature_setting": {
+        "name": "Temperatura nawiewu"
+      }
+    },
     "sensor": {
       "exhaust_air_temperature": {
         "name": "Powietrze wywiewane"

--- a/custom_components/airfi/translations/sv.json
+++ b/custom_components/airfi/translations/sv.json
@@ -118,6 +118,11 @@
         "name": "Ventilation"
       }
     },
+    "number": {
+      "supply_air_temperature_setting": {
+        "name": "Tilluftstemperatur"
+      }
+    },
     "sensor": {
       "exhaust_air_temperature": {
         "name": "Avluft"

--- a/custom_components/airfi/utils/number.py
+++ b/custom_components/airfi/utils/number.py
@@ -6,7 +6,7 @@ HOLDING_REGISTER_TARGET_TEMPERATURE = 5
 """Modbus holding register address for target supply air temperature (4x00005).
 
 Device values: temperature in °C × 10 (e.g. 200 = 20.0 °C).
-Range: 100–210 (10.0 °C – 21.0 °C), step 10 (1.0 °C).
+Range: 130–250 (13.0 °C – 25.0 °C), step 10 (1.0 °C).
 """
 
 HOLDING_REGISTER_MINIMUM_TEMPERATURE = 50

--- a/custom_components/airfi/utils/number.py
+++ b/custom_components/airfi/utils/number.py
@@ -1,0 +1,17 @@
+"""Number register address constants for Airfi."""
+
+from __future__ import annotations
+
+HOLDING_REGISTER_TARGET_TEMPERATURE = 5
+"""Modbus holding register address for target supply air temperature (4x00005).
+
+Device values: temperature in °C × 10 (e.g. 200 = 20.0 °C).
+Range: 100–210 (10.0 °C – 21.0 °C), step 10 (1.0 °C).
+"""
+
+HOLDING_REGISTER_MINIMUM_TEMPERATURE = 50
+"""Modbus holding register address for minimum temperature / bypass (4x00050).
+
+Device values: temperature in °C (not scaled).
+Requires Modbus map version >= 2.1.0 (feature ``minimum_temperature_set``).
+"""

--- a/docs/development/ARCHITECTURE.md
+++ b/docs/development/ARCHITECTURE.md
@@ -45,6 +45,9 @@ custom_components/airfi/
 ├── fan/                     # Fan platform
 │   ├── __init__.py          # Platform setup
 │   └── fan.py               # Ventilation fan entity (5-speed)
+├── number/                  # Number platform
+│   ├── __init__.py          # Platform setup
+│   └── temperature.py       # Supply air temperature setting entity
 ├── sensor/                  # Sensor platform
 │   ├── __init__.py          # Platform setup
 │   ├── humidity.py          # Humidity sensor entity
@@ -58,7 +61,8 @@ custom_components/airfi/
     ├── __init__.py
     ├── discovery.py         # UDP multicast device discovery
     ├── error_mapping.py     # Modbus error code mapping
-    └── fan.py               # Fan speed conversion helpers
+    ├── fan.py               # Fan speed conversion helpers
+    └── number.py            # Number register address constants
 ```
 
 ## Core Components
@@ -75,7 +79,7 @@ and distributes updates to all entities. It is organized as a package with separ
 - `base.py` - Main coordinator class (`AirfiDataUpdateCoordinator`)
 - `data_processing.py` - Data validation, transformation, and caching utilities
 - `error_handling.py` - Error recovery strategies and retry logic
-- `feature_manager.py` - Feature flags based on firmware version
+- `feature_manager.py` - Feature flags based on firmware version and Modbus map version
 
 **Core functionality:**
 
@@ -85,6 +89,7 @@ and distributes updates to all entities. It is organized as a package with separ
 - Automatic retry on transient failures
 - Data validation and transformation before distribution
 - Device recovery via UDP rediscovery when unreachable
+- Feature flag system gating entity availability by Modbus map version
 
 **Key class:** `AirfiDataUpdateCoordinator` (exported from `coordinator/__init__.py`)
 
@@ -174,12 +179,12 @@ Platform entities inherit from both:
     │  Data   │ ← Stored in coordinator.data
     └────┬────┘
          │
-    ┌────┼───────────────┐
-    │    │               │
-    ▼    ▼               ▼
-┌──────┐┌──────────┐┌──────────────┐
-│ Fan  ││ Sensors  ││Binary Sensor │ ← Read from coordinator
-└──────┘└──────────┘└──────────────┘
+    ┌────┼───────────────────────┐
+    │    │               │       │
+    ▼    ▼               ▼       ▼
+┌──────┐┌──────────┐┌──────────────┐┌────────┐
+│ Fan  ││ Sensors  ││Binary Sensor ││ Number │ ← Read from coordinator
+└──────┘└──────────┘└──────────────┘└────────┘
 ```
 
 ## AI Agent Instructions

--- a/docs/user/CONFIGURATION.md
+++ b/docs/user/CONFIGURATION.md
@@ -68,6 +68,14 @@ The integration creates one device with the following entities:
 
 Fan speed presets map directly to the ventilation unit's speed settings (1 = lowest, 5 = highest). Turning the fan off sets speed to 0; turning it on restores the previous speed or defaults to speed 1.
 
+### Controls
+
+| Entity | Type | Range | Description |
+|--------|------|-------|-------------|
+| **Supply air temperature setting** | number | 13–25 °C | Target supply air temperature |
+
+The supply air temperature setting controls the target temperature for air delivered into the rooms. When the device supports minimum temperature parity (Modbus map version ≥ 2.1.0), the minimum temperature setting is also updated automatically to keep both values in sync.
+
 ### Sensors
 
 | Entity | Device Class | Unit | State Class | Description |

--- a/tests/coordinator/test_feature_manager.py
+++ b/tests/coordinator/test_feature_manager.py
@@ -70,3 +70,68 @@ def test_version_string_two_digit_register_value() -> None:
 def test_version_string_one_digit_register_value() -> None:
     """Test that a 1-digit register value produces correct version string."""
     assert version_string(5) == "5.0.0"
+
+
+# ——— Feature flag tests ———
+
+
+@pytest.mark.unit
+def test_feature_flags_all_false_before_initialize() -> None:
+    """Test that all feature flags are False before initialize() is called."""
+    manager = AirfiFeatureManager()
+
+    assert manager.has_feature("minimum_temperature_set") is False
+
+
+@pytest.mark.unit
+def test_feature_flags_unknown_feature_returns_false() -> None:
+    """Test that has_feature returns False for unknown feature names."""
+    manager = AirfiFeatureManager()
+    manager.initialize("Airfi AIRFI-12345", [0, 381, 270])
+
+    assert manager.has_feature("nonexistent_feature") is False
+
+
+@pytest.mark.unit
+def test_feature_flags_modbus_270_all_enabled() -> None:
+    """Test that all features are enabled with modbus map version 2.7.0."""
+    manager = AirfiFeatureManager()
+    manager.initialize("Airfi AIRFI-12345", [0, 381, 270])
+
+    assert manager.has_feature("minimum_temperature_set") is True
+
+
+@pytest.mark.unit
+def test_feature_flags_modbus_250_all_enabled() -> None:
+    """Test that all features are enabled with modbus map version 2.5.0."""
+    manager = AirfiFeatureManager()
+    manager.initialize("Airfi AIRFI-12345", [0, 381, 250])
+
+    assert manager.has_feature("minimum_temperature_set") is True
+
+
+@pytest.mark.unit
+def test_feature_flags_modbus_210_only_minimum_temperature() -> None:
+    """Test that only minimum_temperature_set is enabled with modbus 2.1.0."""
+    manager = AirfiFeatureManager()
+    manager.initialize("Airfi AIRFI-12345", [0, 381, 210])
+
+    assert manager.has_feature("minimum_temperature_set") is True
+
+
+@pytest.mark.unit
+def test_feature_flags_modbus_200_none_enabled() -> None:
+    """Test that no features are enabled with modbus map version 2.0.0."""
+    manager = AirfiFeatureManager()
+    manager.initialize("Airfi AIRFI-12345", [0, 381, 200])
+
+    assert manager.has_feature("minimum_temperature_set") is False
+
+
+@pytest.mark.unit
+def test_feature_flags_modbus_150_none_enabled() -> None:
+    """Test that no features are enabled with modbus map version 1.5.0."""
+    manager = AirfiFeatureManager()
+    manager.initialize("Airfi AIRFI-12345", [0, 381, 150])
+
+    assert manager.has_feature("minimum_temperature_set") is False

--- a/tests/number/__init__.py
+++ b/tests/number/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Airfi number platform."""

--- a/tests/number/test_temperature.py
+++ b/tests/number/test_temperature.py
@@ -121,6 +121,6 @@ def test_entity_description_constraints() -> None:
     """Test that the entity description has correct min/max/step/mode."""
     desc = ENTITY_DESCRIPTIONS[0]
     assert desc.key == "supply_air_temperature_setting"
-    assert desc.native_min_value == 10.0
-    assert desc.native_max_value == 21.0
+    assert desc.native_min_value == 13.0
+    assert desc.native_max_value == 25.0
     assert desc.native_step == 1.0

--- a/tests/number/test_temperature.py
+++ b/tests/number/test_temperature.py
@@ -1,0 +1,126 @@
+"""Test supply air temperature number entity for Airfi."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.airfi.number.temperature import ENTITY_DESCRIPTIONS, AirfiTemperatureNumber
+
+
+def _build_coordinator(
+    holding_registers: list[int],
+    *,
+    has_minimum_temperature: bool = False,
+) -> MagicMock:
+    """Build a coordinator mock with holding register data."""
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry-1"
+    config_entry.domain = "airfi"
+    config_entry.title = "Airfi Unit"
+    config_entry.data = {"host": "192.168.1.10"}
+
+    feature_manager = MagicMock()
+    feature_manager.has_feature = MagicMock(
+        side_effect=lambda f: f == "minimum_temperature_set" and has_minimum_temperature
+    )
+
+    coordinator = MagicMock()
+    coordinator.config_entry = config_entry
+    coordinator.async_set_holding_register = AsyncMock()
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.feature_manager = feature_manager
+    coordinator.data = {
+        "holding_registers": holding_registers,
+        "model": "Airfi",
+        "firmware_version": "3.8.1",
+    }
+    return coordinator
+
+
+@pytest.mark.unit
+def test_native_value_reads_register_5() -> None:
+    """Test that native_value reads holding register 5 and divides by 10."""
+    coordinator = _build_coordinator([0, 0, 0, 0, 200])  # HR5 = 200 => 20.0
+    entity = AirfiTemperatureNumber(coordinator, ENTITY_DESCRIPTIONS[0])
+
+    assert entity.native_value == 20.0
+
+
+@pytest.mark.unit
+def test_native_value_fractional() -> None:
+    """Test that native_value returns fractional values correctly."""
+    coordinator = _build_coordinator([0, 0, 0, 0, 185])  # HR5 = 185 => 18.5
+    entity = AirfiTemperatureNumber(coordinator, ENTITY_DESCRIPTIONS[0])
+
+    assert entity.native_value == 18.5
+
+
+@pytest.mark.unit
+def test_native_value_returns_none_when_register_missing() -> None:
+    """Test that native_value returns None when register 5 is out of range."""
+    coordinator = _build_coordinator([0, 0, 0])  # Only 3 registers
+    entity = AirfiTemperatureNumber(coordinator, ENTITY_DESCRIPTIONS[0])
+
+    assert entity.native_value is None
+
+
+@pytest.mark.unit
+async def test_set_value_writes_register_5() -> None:
+    """Test that setting the value writes °C × 10 to register 5."""
+    coordinator = _build_coordinator([0, 0, 0, 0, 200])
+    entity = AirfiTemperatureNumber(coordinator, ENTITY_DESCRIPTIONS[0])
+
+    await entity.async_set_native_value(18.0)
+
+    coordinator.async_set_holding_register.assert_any_await(5, 180)
+
+
+@pytest.mark.unit
+async def test_set_value_does_not_write_minimum_without_feature() -> None:
+    """Test that register 50 is NOT written when feature is unavailable."""
+    coordinator = _build_coordinator([0, 0, 0, 0, 200], has_minimum_temperature=False)
+    entity = AirfiTemperatureNumber(coordinator, ENTITY_DESCRIPTIONS[0])
+
+    await entity.async_set_native_value(18.0)
+
+    assert coordinator.async_set_holding_register.await_count == 1
+    coordinator.async_set_holding_register.assert_awaited_once_with(5, 180)
+
+
+@pytest.mark.unit
+async def test_set_value_writes_minimum_with_feature() -> None:
+    """Test that register 50 is also written when minimum_temperature_set is available."""
+    coordinator = _build_coordinator([0, 0, 0, 0, 200], has_minimum_temperature=True)
+    entity = AirfiTemperatureNumber(coordinator, ENTITY_DESCRIPTIONS[0])
+
+    await entity.async_set_native_value(18.0)
+
+    calls = coordinator.async_set_holding_register.call_args_list
+    assert len(calls) == 2
+    # First call: register 5 = 180 (18.0 × 10)
+    assert calls[0][0] == (5, 180)
+    # Second call: register 50 = 18 (raw °C)
+    assert calls[1][0] == (50, 18)
+
+
+@pytest.mark.unit
+async def test_set_value_triggers_refresh() -> None:
+    """Test that async_request_refresh is called after writing."""
+    coordinator = _build_coordinator([0, 0, 0, 0, 200])
+    entity = AirfiTemperatureNumber(coordinator, ENTITY_DESCRIPTIONS[0])
+
+    await entity.async_set_native_value(20.0)
+
+    coordinator.async_request_refresh.assert_awaited_once()
+
+
+@pytest.mark.unit
+def test_entity_description_constraints() -> None:
+    """Test that the entity description has correct min/max/step/mode."""
+    desc = ENTITY_DESCRIPTIONS[0]
+    assert desc.key == "supply_air_temperature_setting"
+    assert desc.native_min_value == 10.0
+    assert desc.native_max_value == 21.0
+    assert desc.native_step == 1.0

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -9,13 +9,18 @@ import pytest
 from custom_components.airfi.binary_sensor import async_setup_entry as binary_sensor_setup
 from custom_components.airfi.data import AirfiData
 from custom_components.airfi.fan import async_setup_entry as fan_setup
+from custom_components.airfi.number import async_setup_entry as number_setup
 from custom_components.airfi.sensor import async_setup_entry as sensor_setup
 
 
-def _make_entry(hass) -> MagicMock:
+def _make_entry(hass, *, features: dict[str, bool] | None = None) -> MagicMock:
     """Build a mock config entry with runtime data containing a coordinator."""
+    feature_manager = MagicMock()
+    feature_manager.has_feature = MagicMock(side_effect=lambda f: (features or {}).get(f, False))
+
     coordinator = MagicMock()
     coordinator.data = {}
+    coordinator.feature_manager = feature_manager
     entry = MagicMock()
     entry.runtime_data = AirfiData(
         client=MagicMock(),
@@ -51,3 +56,12 @@ async def test_sensor_setup_entry_adds_entities(hass) -> None:
     added = []
     await sensor_setup(hass, entry, added.extend)
     assert len(added) >= 5  # 1 humidity + 4 temperature
+
+
+@pytest.mark.unit
+async def test_number_setup_entry_adds_entities(hass) -> None:
+    """Test that number platform adds temperature number entity."""
+    entry = _make_entry(hass)
+    added = []
+    await number_setup(hass, entry, added.extend)
+    assert len(added) >= 1


### PR DESCRIPTION
## Description

This pull request introduces a new "number" platform to the Airfi integration, enabling control of the supply air temperature setpoint. It implements a feature flag system based on the Modbus map version to conditionally expose features, and includes comprehensive tests and documentation updates. The most important changes are summarized below.

---

**New Number Platform and Supply Air Temperature Control:**

* Added a new `number` platform, exposing a `supply_air_temperature_setting` entity for direct control of the supply air temperature. This entity reads/writes Modbus holding register 5 and, if supported, also updates register 50 for minimum temperature parity. (`custom_components/airfi/number/__init__.py` [[1]](diffhunk://#diff-aa02d54335de6a78a40d72716cda903d43c25a49cf77cf00d62cbbff0cbbd2f5R1-R32) `custom_components/airfi/number/temperature.py` [[2]](diffhunk://#diff-6e82060a83d76f5e5dd87b2f58e9acce632e93a6283c45862225c83d39b239d0R1-R57) `custom_components/airfi/utils/number.py` [[3]](diffhunk://#diff-0aae691a962857408dfd2d431f11fc97c207c00a02fd0c4326683fbab56be4e2R1-R17)
* Registered the number platform in the integration setup and updated icons and translations for the new entity. (`custom_components/airfi/__init__.py` [[1]](diffhunk://#diff-3e98492243dcac51d46182a148d44422b4946a1372a9e22e7c5e147876650abfL34-R39) `custom_components/airfi/icons.json` [[2]](diffhunk://#diff-07dbbb283016ef627f5cb05d31ef16f2a57a07cbc515fdb5cea84134aff83628R19-R23) `custom_components/airfi/translations/en.json` [[3]](diffhunk://#diff-93b463d36f3bb5e85114df7eacf59f8c2a71215b34d22ab014baac2bf110e2b3R121-R125) `custom_components/airfi/translations/fi.json` [[4]](diffhunk://#diff-e552df50ef59c3e62abd115a189927d6b1e68c9deaaa6939cbf102badf4cfbf1R121-R125) `custom_components/airfi/translations/pl.json` [[5]](diffhunk://#diff-c9eceef556e16b8b43721af928442eea2c38523346aa46435ea2ab9d4a0ab836R121-R125) `custom_components/airfi/translations/sv.json` [[6]](diffhunk://#diff-34a0ea22b76e77fde5a85e713aaac3f3206faeafe7f3caa2e17328b5a29b9bafR121-R125)

**Feature Flag System (Modbus Map Version Gating):**

* Introduced a feature flag system in `AirfiFeatureManager` that enables or disables features based on the detected Modbus map version, with the first flag being `minimum_temperature_set` (enabled for version ≥ 2.1.0). (`custom_components/airfi/coordinator/feature_manager.py` [[1]](diffhunk://#diff-061f1a11cfd711977bcbf93a5747d46e139a2337315bc96dd724bfa3583d911eL4-R4) [[2]](diffhunk://#diff-061f1a11cfd711977bcbf93a5747d46e139a2337315bc96dd724bfa3583d911eR35-R45) [[3]](diffhunk://#diff-061f1a11cfd711977bcbf93a5747d46e139a2337315bc96dd724bfa3583d911eR74) [[4]](diffhunk://#diff-061f1a11cfd711977bcbf93a5747d46e139a2337315bc96dd724bfa3583d911eR147-R162)
* Updated documentation to describe the feature flag system and how it gates entity availability. (`docs/development/ARCHITECTURE.md` [[1]](diffhunk://#diff-2817d8bbe6ebec58003d6cb387109c06e16213509289b1b146aefbd293211397L78-R82) [[2]](diffhunk://#diff-2817d8bbe6ebec58003d6cb387109c06e16213509289b1b146aefbd293211397R92)

**Documentation Updates:**

* Updated architecture and user documentation to include the new number platform, supply air temperature control, and feature flag system. (`docs/development/ARCHITECTURE.md` [[1]](diffhunk://#diff-2817d8bbe6ebec58003d6cb387109c06e16213509289b1b146aefbd293211397R48-R50) [[2]](diffhunk://#diff-2817d8bbe6ebec58003d6cb387109c06e16213509289b1b146aefbd293211397L61-R65) [[3]](diffhunk://#diff-2817d8bbe6ebec58003d6cb387109c06e16213509289b1b146aefbd293211397L177-R187) `docs/user/CONFIGURATION.md` [[4]](diffhunk://#diff-64c84e3922eb78f8000165740a323d6af33b430e7c219fe32458b638ebd0998bR71-R78)

**Testing:**

* Added comprehensive unit tests for the feature flag system and the number entity, ensuring correct register handling and feature gating. (`tests/coordinator/test_feature_manager.py` [[1]](diffhunk://#diff-2630b6c0193aa29e9bcb85d23f7fe8042789d53b645fa6c9ad3e3db737b75e30R73-R137) `tests/number/__init__.py` [[2]](diffhunk://#diff-04ae3692ca74f1e7787bd538fc8335a25d62f78020c9ccb2897f478b6ddd5da5R1) `tests/number/test_temperature.py` [[3]](diffhunk://#diff-c41deeddbf8e64a80c592be1f71c4472872ed9c4e978f64ad987cb40232847ebR1-R126)

---

These changes add user-facing supply air temperature control, ensure compatibility with device capabilities, and improve maintainability and test coverage.

## Related Issue

Resolves #17

## Type of Change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvements

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] My code follows the code style of this project (run `script/lint`)
- [x] I have updated the documentation accordingly
- [x] I have updated the translations if needed
