### PR TITLE
Function switches

### DIFF
--- a/custom_components/airfi/__init__.py
+++ b/custom_components/airfi/__init__.py
@@ -36,6 +36,7 @@ PLATFORMS: list[Platform] = [
     Platform.FAN,
     Platform.NUMBER,
     Platform.SENSOR,
+    Platform.SWITCH,
 ]
 
 # This integration is configured via config entries only

--- a/custom_components/airfi/coordinator/feature_manager.py
+++ b/custom_components/airfi/coordinator/feature_manager.py
@@ -35,6 +35,9 @@ class AirfiFeatureManager:
     # Feature flags gated by minimum Modbus map version
     _FEATURE_VERSION_MAP: dict[str, str] = {
         "minimum_temperature_set": "2.1.0",
+        "fireplace_function": "2.5.0",
+        "boosted_cooling": "2.5.0",
+        "sauna_function": "2.5.0",
     }
 
     def __init__(self) -> None:

--- a/custom_components/airfi/icons.json
+++ b/custom_components/airfi/icons.json
@@ -64,6 +64,26 @@
           "unavailable": "mdi:water-off"
         }
       }
+    },
+    "switch": {
+      "fireplace_function": {
+        "default": "mdi:fireplace-off",
+        "state": {
+          "on": "mdi:fireplace"
+        }
+      },
+      "sauna_function": {
+        "default": "mdi:radiator-off",
+        "state": {
+          "on": "mdi:radiator"
+        }
+      },
+      "boosted_cooling": {
+        "default": "mdi:fan-off",
+        "state": {
+          "on": "mdi:fan-plus"
+        }
+      }
     }
   }
 }

--- a/custom_components/airfi/switch/__init__.py
+++ b/custom_components/airfi/switch/__init__.py
@@ -1,0 +1,35 @@
+"""Switch platform for Airfi."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from custom_components.airfi.const import PARALLEL_UPDATES as PARALLEL_UPDATES
+
+from .functions import ENTITY_DESCRIPTIONS as FUNCTION_DESCRIPTIONS, AirfiFunctionSwitch
+
+if TYPE_CHECKING:
+    from custom_components.airfi.data import AirfiConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: AirfiConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the switch platform.
+
+    Only creates entities whose feature flag is supported by the device's
+    Modbus register map version.
+    """
+    coordinator = entry.runtime_data.coordinator
+    async_add_entities(
+        AirfiFunctionSwitch(
+            coordinator=coordinator,
+            entity_description=desc,
+        )
+        for desc in FUNCTION_DESCRIPTIONS
+        if coordinator.feature_manager.has_feature(desc.feature_flag)
+    )

--- a/custom_components/airfi/switch/functions.py
+++ b/custom_components/airfi/switch/functions.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from custom_components.airfi.coordinator import AirfiDataUpdateCoordinator
 from custom_components.airfi.entity import AirfiEntity
 from custom_components.airfi.utils.switch import (
     HOLDING_REGISTER_BOOSTED_COOLING,
@@ -13,6 +12,9 @@ from custom_components.airfi.utils.switch import (
     HOLDING_REGISTER_SAUNA_FUNCTION,
 )
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+
+if TYPE_CHECKING:
+    from custom_components.airfi.coordinator import AirfiDataUpdateCoordinator
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/custom_components/airfi/switch/functions.py
+++ b/custom_components/airfi/switch/functions.py
@@ -1,0 +1,101 @@
+"""Switch entities for Airfi special functions (sauna, fireplace, boosted cooling)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from custom_components.airfi.coordinator import AirfiDataUpdateCoordinator
+from custom_components.airfi.entity import AirfiEntity
+from custom_components.airfi.utils.switch import (
+    HOLDING_REGISTER_BOOSTED_COOLING,
+    HOLDING_REGISTER_FIREPLACE_FUNCTION,
+    HOLDING_REGISTER_SAUNA_FUNCTION,
+)
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+
+
+@dataclass(frozen=True, kw_only=True)
+class AirfiSwitchEntityDescription(SwitchEntityDescription):
+    """Extended switch description with Modbus register address and feature flag."""
+
+    register_address: int
+    feature_flag: str
+
+
+ENTITY_DESCRIPTIONS: tuple[AirfiSwitchEntityDescription, ...] = (
+    AirfiSwitchEntityDescription(
+        key="fireplace_function",
+        translation_key="fireplace_function",
+        register_address=HOLDING_REGISTER_FIREPLACE_FUNCTION,
+        feature_flag="fireplace_function",
+        entity_registry_enabled_default=False,
+    ),
+    AirfiSwitchEntityDescription(
+        key="sauna_function",
+        translation_key="sauna_function",
+        register_address=HOLDING_REGISTER_SAUNA_FUNCTION,
+        feature_flag="sauna_function",
+        entity_registry_enabled_default=False,
+    ),
+    AirfiSwitchEntityDescription(
+        key="boosted_cooling",
+        translation_key="boosted_cooling",
+        register_address=HOLDING_REGISTER_BOOSTED_COOLING,
+        feature_flag="boosted_cooling",
+        entity_registry_enabled_default=False,
+    ),
+)
+
+
+class AirfiFunctionSwitch(SwitchEntity, AirfiEntity):
+    """On/off switch backed by a single holding register (0/1).
+
+    Each switch controls a special ventilation function (sauna, fireplace,
+    boosted cooling) via a dedicated Modbus holding register.
+
+    Uses optimistic state updates: writes the expected value to HA immediately
+    after the Modbus write succeeds, then requests a coordinator refresh to
+    confirm. This prevents the UI from briefly bouncing back to the old state.
+    """
+
+    entity_description: AirfiSwitchEntityDescription
+
+    def __init__(
+        self,
+        coordinator: AirfiDataUpdateCoordinator,
+        entity_description: AirfiSwitchEntityDescription,
+    ) -> None:
+        """Initialize with no optimistic state."""
+        super().__init__(coordinator, entity_description)
+        self._optimistic_state: bool | None = None
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if the function is active."""
+        if self._optimistic_state is not None:
+            return self._optimistic_state
+        registers: list[int] = self.coordinator.data.get("holding_registers", [])
+        index = self.entity_description.register_address - 1
+        if index >= len(registers):
+            return None
+        return registers[index] == 1
+
+    def _handle_coordinator_update(self) -> None:
+        """Clear optimistic state when real data arrives from coordinator."""
+        self._optimistic_state = None
+        super()._handle_coordinator_update()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Activate the function."""
+        await self.coordinator.async_set_holding_register(self.entity_description.register_address, 1)
+        self._optimistic_state = True
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Deactivate the function."""
+        await self.coordinator.async_set_holding_register(self.entity_description.register_address, 0)
+        self._optimistic_state = False
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()

--- a/custom_components/airfi/translations/en.json
+++ b/custom_components/airfi/translations/en.json
@@ -145,6 +145,17 @@
       "supply_air_temperature": {
         "name": "Supply air"
       }
+    },
+    "switch": {
+      "fireplace_function": {
+        "name": "Fireplace function"
+      },
+      "sauna_function": {
+        "name": "Sauna function"
+      },
+      "boosted_cooling": {
+        "name": "Boosted cooling"
+      }
     }
   }
 }

--- a/custom_components/airfi/translations/fi.json
+++ b/custom_components/airfi/translations/fi.json
@@ -154,7 +154,7 @@
         "name": "Saunatoiminto"
       },
       "boosted_cooling": {
-        "name": "Tehostettu jäähdytys"
+        "name": "Tehostettu viilennys"
       }
     }
   }

--- a/custom_components/airfi/translations/fi.json
+++ b/custom_components/airfi/translations/fi.json
@@ -145,6 +145,17 @@
       "supply_air_temperature": {
         "name": "Tuloilma"
       }
+    },
+    "switch": {
+      "fireplace_function": {
+        "name": "Takkatoiminto"
+      },
+      "sauna_function": {
+        "name": "Saunatoiminto"
+      },
+      "boosted_cooling": {
+        "name": "Tehostettu jäähdytys"
+      }
     }
   }
 }

--- a/custom_components/airfi/translations/pl.json
+++ b/custom_components/airfi/translations/pl.json
@@ -145,6 +145,17 @@
       "supply_air_temperature": {
         "name": "Powietrze nawiewane"
       }
+    },
+    "switch": {
+      "fireplace_function": {
+        "name": "Funkcja kominka"
+      },
+      "sauna_function": {
+        "name": "Funkcja sauny"
+      },
+      "boosted_cooling": {
+        "name": "Wzmocnione chłodzenie"
+      }
     }
   }
 }

--- a/custom_components/airfi/translations/sv.json
+++ b/custom_components/airfi/translations/sv.json
@@ -145,6 +145,17 @@
       "supply_air_temperature": {
         "name": "Tilluft"
       }
+    },
+    "switch": {
+      "fireplace_function": {
+        "name": "Spisfunktion"
+      },
+      "sauna_function": {
+        "name": "Bastufunktion"
+      },
+      "boosted_cooling": {
+        "name": "Förstärkt kylning"
+      }
     }
   }
 }

--- a/custom_components/airfi/translations/sv.json
+++ b/custom_components/airfi/translations/sv.json
@@ -148,13 +148,13 @@
     },
     "switch": {
       "fireplace_function": {
-        "name": "Spisfunktion"
+        "name": "Braständningsfunktion"
       },
       "sauna_function": {
         "name": "Bastufunktion"
       },
       "boosted_cooling": {
-        "name": "Förstärkt kylning"
+        "name": "Förbättrad kylning"
       }
     }
   }

--- a/custom_components/airfi/utils/switch.py
+++ b/custom_components/airfi/utils/switch.py
@@ -1,0 +1,24 @@
+"""Switch register address constants for Airfi."""
+
+from __future__ import annotations
+
+HOLDING_REGISTER_BOOSTED_COOLING = 51
+"""Modbus holding register address for boosted cooling (4x00051).
+
+Device values: 0 = off, 1 = on.
+Requires Modbus map version >= 2.5.0.
+"""
+
+HOLDING_REGISTER_SAUNA_FUNCTION = 57
+"""Modbus holding register address for sauna function (4x00057).
+
+Device values: 0 = off, 1 = on.
+Requires Modbus map version >= 2.5.0.
+"""
+
+HOLDING_REGISTER_FIREPLACE_FUNCTION = 58
+"""Modbus holding register address for fireplace function (4x00058).
+
+Device values: 0 = off, 1 = on.
+Requires Modbus map version >= 2.5.0.
+"""

--- a/docs/development/ARCHITECTURE.md
+++ b/docs/development/ARCHITECTURE.md
@@ -52,6 +52,9 @@ custom_components/airfi/
 │   ├── __init__.py          # Platform setup
 │   ├── humidity.py          # Humidity sensor entity
 │   └── temperature.py       # Temperature sensor entities (4 types)
+├── switch/                  # Switch platform (feature-gated)
+│   ├── __init__.py          # Platform setup (filters by feature flags)
+│   └── functions.py         # Special function switches (sauna, fireplace, boost)
 ├── translations/            # Localization files
 │   ├── en.json              # English
 │   ├── fi.json              # Finnish
@@ -62,7 +65,8 @@ custom_components/airfi/
     ├── discovery.py         # UDP multicast device discovery
     ├── error_mapping.py     # Modbus error code mapping
     ├── fan.py               # Fan speed conversion helpers
-    └── number.py            # Number register address constants
+    ├── number.py            # Number register address constants
+    └── switch.py            # Switch register address constants
 ```
 
 ## Core Components
@@ -182,9 +186,9 @@ Platform entities inherit from both:
     ┌────┼───────────────────────┐
     │    │               │       │
     ▼    ▼               ▼       ▼
-┌──────┐┌──────────┐┌──────────────┐┌────────┐
-│ Fan  ││ Sensors  ││Binary Sensor ││ Number │ ← Read from coordinator
-└──────┘└──────────┘└──────────────┘└────────┘
+┌──────┐┌──────────┐┌──────────────┐┌─────────────────┐
+│ Fan  ││ Sensors  ││Binary Sensor ││ Number / Switch │ ← Read from coordinator
+└──────┘└──────────┘└──────────────┘└─────────────────┘
 ```
 
 ## AI Agent Instructions

--- a/docs/user/CONFIGURATION.md
+++ b/docs/user/CONFIGURATION.md
@@ -100,6 +100,25 @@ These entities are disabled by default and can be enabled in entity settings if 
 
 The connectivity sensor is redundant in most cases — all entities automatically become unavailable when the device is unreachable. The version sensors are useful for tracking firmware updates.
 
+### Special Function Switches (Disabled by Default, Feature-Gated)
+
+These switches are only available when the device's Modbus register map version supports them (≥ 2.5.0). They are disabled by default and must be manually enabled:
+
+| Entity | Feature Flag | Description |
+|--------|-------------|-------------|
+| **Fireplace function** | `fireplace_function` | When activated, overpressure is maintained for 30 min. |
+| **Sauna function** | `sauna_function` | When activated, prevents ventilation increase for 30 min when unit detects increase in humidity. |
+| **Boosted cooling** | `boosted_cooling` | When activated, the unit monitors temperatures and boosts air volumes as needed depending on conditions. Useful especially during summer time to draw in cool outside air during nighttime. |
+
+To enable a switch:
+
+1. Go to **Settings** → **Devices & Services** → **Entities**
+2. Find the switch entity (it may be hidden — use the filter)
+3. Click the settings icon (⚙)
+4. Toggle **Enable entity** on
+
+**Note:** If the switches don't appear at all, your unit's firmware may not support these features. Check the Modbus register version diagnostic sensor — it needs to be 2.5.0 or newer.
+
 ### Disabling Entities
 
 If you don't need certain entities:

--- a/tests/coordinator/test_feature_manager.py
+++ b/tests/coordinator/test_feature_manager.py
@@ -80,6 +80,9 @@ def test_feature_flags_all_false_before_initialize() -> None:
     """Test that all feature flags are False before initialize() is called."""
     manager = AirfiFeatureManager()
 
+    assert manager.has_feature("fireplace_function") is False
+    assert manager.has_feature("sauna_function") is False
+    assert manager.has_feature("boosted_cooling") is False
     assert manager.has_feature("minimum_temperature_set") is False
 
 
@@ -99,6 +102,9 @@ def test_feature_flags_modbus_270_all_enabled() -> None:
     manager.initialize("Airfi AIRFI-12345", [0, 381, 270])
 
     assert manager.has_feature("minimum_temperature_set") is True
+    assert manager.has_feature("fireplace_function") is True
+    assert manager.has_feature("sauna_function") is True
+    assert manager.has_feature("boosted_cooling") is True
 
 
 @pytest.mark.unit
@@ -108,6 +114,9 @@ def test_feature_flags_modbus_250_all_enabled() -> None:
     manager.initialize("Airfi AIRFI-12345", [0, 381, 250])
 
     assert manager.has_feature("minimum_temperature_set") is True
+    assert manager.has_feature("fireplace_function") is True
+    assert manager.has_feature("sauna_function") is True
+    assert manager.has_feature("boosted_cooling") is True
 
 
 @pytest.mark.unit
@@ -117,6 +126,9 @@ def test_feature_flags_modbus_210_only_minimum_temperature() -> None:
     manager.initialize("Airfi AIRFI-12345", [0, 381, 210])
 
     assert manager.has_feature("minimum_temperature_set") is True
+    assert manager.has_feature("fireplace_function") is False
+    assert manager.has_feature("sauna_function") is False
+    assert manager.has_feature("boosted_cooling") is False
 
 
 @pytest.mark.unit
@@ -126,6 +138,9 @@ def test_feature_flags_modbus_200_none_enabled() -> None:
     manager.initialize("Airfi AIRFI-12345", [0, 381, 200])
 
     assert manager.has_feature("minimum_temperature_set") is False
+    assert manager.has_feature("fireplace_function") is False
+    assert manager.has_feature("sauna_function") is False
+    assert manager.has_feature("boosted_cooling") is False
 
 
 @pytest.mark.unit
@@ -135,3 +150,4 @@ def test_feature_flags_modbus_150_none_enabled() -> None:
     manager.initialize("Airfi AIRFI-12345", [0, 381, 150])
 
     assert manager.has_feature("minimum_temperature_set") is False
+    assert manager.has_feature("fireplace_function") is False

--- a/tests/coordinator/test_feature_manager.py
+++ b/tests/coordinator/test_feature_manager.py
@@ -151,3 +151,5 @@ def test_feature_flags_modbus_150_none_enabled() -> None:
 
     assert manager.has_feature("minimum_temperature_set") is False
     assert manager.has_feature("fireplace_function") is False
+    assert manager.has_feature("sauna_function") is False
+    assert manager.has_feature("boosted_cooling") is False

--- a/tests/fan/test_fan.py
+++ b/tests/fan/test_fan.py
@@ -103,6 +103,9 @@ async def test_fan_turn_on_writes_0_to_register_12() -> None:
     await entity.async_turn_on()
 
     entity.coordinator.async_set_holding_register.assert_awaited_once_with(12, 0)
+    entity.coordinator.async_request_refresh.assert_awaited_once()
+    # Optimistic state was written to HA
+    entity.async_write_ha_state.assert_called_once()
 
 
 @pytest.mark.unit
@@ -113,6 +116,9 @@ async def test_fan_turn_off_writes_1_to_register_12() -> None:
     await entity.async_turn_off()
 
     entity.coordinator.async_set_holding_register.assert_awaited_once_with(12, 1)
+    entity.coordinator.async_request_refresh.assert_awaited_once()
+    # Optimistic state was written to HA
+    entity.async_write_ha_state.assert_called_once()
 
 
 @pytest.mark.unit
@@ -135,6 +141,9 @@ async def test_fan_set_percentage_writes_device_speed(
     assert calls[0][0] == (12, 0)
     # Second call: set speed (register 1 = expected_device_speed)
     assert calls[1][0] == (1, expected_device_speed)
+    # Optimistic state written and coordinator refresh requested
+    entity.async_write_ha_state.assert_called_once()
+    entity.coordinator.async_request_refresh.assert_awaited_once()
 
 
 @pytest.mark.unit
@@ -145,6 +154,8 @@ async def test_fan_set_percentage_0_turns_off() -> None:
     await entity.async_set_percentage(0)
 
     entity.coordinator.async_set_holding_register.assert_awaited_once_with(12, 1)
+    entity.coordinator.async_request_refresh.assert_awaited_once()
+    entity.async_write_ha_state.assert_called_once()
 
 
 @pytest.mark.unit
@@ -162,6 +173,8 @@ async def test_fan_turn_on_with_percentage() -> None:
     assert calls[1][0] == (12, 0)
     # Third call: set speed (register 1 = 3)
     assert calls[2][0] == (1, 3)
+    entity.async_write_ha_state.assert_called_once()
+    entity.coordinator.async_request_refresh.assert_awaited_once()
 
 
 @pytest.mark.unit
@@ -177,3 +190,44 @@ async def test_fan_set_percentage_turns_on_if_off() -> None:
     assert calls[0][0] == (12, 0)
     # Second call: set speed (register 1 = 3)
     assert calls[1][0] == (1, 3)
+    entity.async_write_ha_state.assert_called_once()
+    entity.coordinator.async_request_refresh.assert_awaited_once()
+
+
+@pytest.mark.unit
+async def test_fan_optimistic_state_set_and_cleared() -> None:
+    """Test optimistic state is applied after write and cleared on coordinator update."""
+    # Start with fan off (register 12 == 1)
+    entity = _build_fan([3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+
+    # Turn on without percentage: optimistic flag should be set
+    await entity.async_turn_on()
+    assert entity._optimistic_is_on is True  # noqa: SLF001
+    assert entity.is_on is True
+    entity.async_write_ha_state.assert_called()
+
+    # Clear optimistic state via coordinator update
+    entity._handle_coordinator_update()  # noqa: SLF001
+    assert entity._optimistic_is_on is None  # noqa: SLF001
+
+
+@pytest.mark.unit
+async def test_fan_percentage_returns_optimistic_and_cleared() -> None:
+    """Percentage returns the optimistic value immediately after set and clears on update."""
+    # Start with device speed 2 (maps to 40%) so we can observe a change
+    entity = _build_fan([2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+
+    # Set to 100% (device speed 5) — async_set_percentage sets optimistic_percentage
+    await entity.async_set_percentage(100)
+
+    # Optimistic value should be returned by the property (covers line 73)
+    assert entity._optimistic_percentage == 100  # noqa: SLF001
+    assert entity.percentage == 100
+
+    # Simulate coordinator delivering the new live register values (speed=5, active=0)
+    entity.coordinator.data["holding_registers"] = [5] + [0] * 10 + [0]
+    # Now clear optimistic state as coordinator would do on update
+    entity._handle_coordinator_update()  # noqa: SLF001
+    assert entity._optimistic_percentage is None  # noqa: SLF001
+    # Device speed 5 maps to 100%
+    assert entity.percentage == 100

--- a/tests/switch/__init__.py
+++ b/tests/switch/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Airfi switch platform."""

--- a/tests/switch/test_functions.py
+++ b/tests/switch/test_functions.py
@@ -220,13 +220,13 @@ async def test_optimistic_state_set_and_cleared() -> None:
 
     # After turn_on, optimistic state should be set and visible via is_on
     await entity.async_turn_on()
-    assert entity._optimistic_state is True
+    assert entity._optimistic_state is True  # noqa: SLF001
     assert entity.is_on is True
     entity.async_write_ha_state.assert_called()
 
     # Simulate coordinator update which should clear optimistic state
-    entity._handle_coordinator_update()
-    assert entity._optimistic_state is None
+    entity._handle_coordinator_update()  # noqa: SLF001
+    assert entity._optimistic_state is None  # noqa: SLF001
 
 
 @pytest.mark.unit

--- a/tests/switch/test_functions.py
+++ b/tests/switch/test_functions.py
@@ -1,0 +1,241 @@
+"""Test switch entities for Airfi special functions."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.airfi.switch.functions import ENTITY_DESCRIPTIONS, AirfiFunctionSwitch
+
+
+def _build_coordinator(holding_registers: list[int]) -> MagicMock:
+    """Build a coordinator mock with holding register data."""
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry-1"
+    config_entry.domain = "airfi"
+    config_entry.title = "Airfi Unit"
+    config_entry.data = {"host": "192.168.1.10"}
+
+    coordinator = MagicMock()
+    coordinator.config_entry = config_entry
+    coordinator.async_set_holding_register = AsyncMock()
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.data = {
+        "holding_registers": holding_registers,
+        "model": "Airfi",
+        "firmware_version": "3.8.1",
+    }
+    return coordinator
+
+
+def _build_switch(key: str, holding_registers: list[int]) -> AirfiFunctionSwitch:
+    """Build a switch entity with mocked async_write_ha_state for optimistic updates."""
+    desc = _description_for(key)
+    coordinator = _build_coordinator(holding_registers)
+    entity = AirfiFunctionSwitch(coordinator, desc)
+    entity.async_write_ha_state = MagicMock()
+    return entity
+
+
+def _registers_with(address: int, value: int) -> list[int]:
+    """Return a list of holding registers with a given value at address (1-based)."""
+    regs = [0] * 59  # Full 2.7.0 register set
+    regs[address - 1] = value
+    return regs
+
+
+def _description_for(key: str):
+    """Get switch description by key."""
+    return next(d for d in ENTITY_DESCRIPTIONS if d.key == key)
+
+
+# ——— Fireplace function tests ———
+
+
+@pytest.mark.unit
+def test_fireplace_is_on() -> None:
+    """Test fireplace switch reads ON when register 58 is 1."""
+    desc = _description_for("fireplace_function")
+    coordinator = _build_coordinator(_registers_with(58, 1))
+    entity = AirfiFunctionSwitch(coordinator, desc)
+
+    assert entity.is_on is True
+
+
+@pytest.mark.unit
+def test_fireplace_is_off() -> None:
+    """Test fireplace switch reads OFF when register 58 is 0."""
+    desc = _description_for("fireplace_function")
+    coordinator = _build_coordinator(_registers_with(58, 0))
+    entity = AirfiFunctionSwitch(coordinator, desc)
+
+    assert entity.is_on is False
+
+
+@pytest.mark.unit
+async def test_fireplace_turn_on() -> None:
+    """Test turning on fireplace writes 1 to register 58."""
+    entity = _build_switch("fireplace_function", _registers_with(58, 0))
+
+    await entity.async_turn_on()
+
+    entity.coordinator.async_set_holding_register.assert_awaited_once_with(58, 1)
+    entity.coordinator.async_request_refresh.assert_awaited_once()
+    # Optimistic write should have been performed
+    entity.async_write_ha_state.assert_called_once()
+
+
+@pytest.mark.unit
+async def test_fireplace_turn_off() -> None:
+    """Test turning off fireplace writes 0 to register 58."""
+    entity = _build_switch("fireplace_function", _registers_with(58, 1))
+
+    await entity.async_turn_off()
+
+    entity.coordinator.async_set_holding_register.assert_awaited_once_with(58, 0)
+    entity.coordinator.async_request_refresh.assert_awaited_once()
+    # Optimistic write should have been performed
+    entity.async_write_ha_state.assert_called_once()
+
+
+# ——— Sauna function tests ———
+
+
+@pytest.mark.unit
+def test_sauna_is_on() -> None:
+    """Test sauna switch reads ON when register 57 is 1."""
+    desc = _description_for("sauna_function")
+    coordinator = _build_coordinator(_registers_with(57, 1))
+    entity = AirfiFunctionSwitch(coordinator, desc)
+
+    assert entity.is_on is True
+
+
+@pytest.mark.unit
+def test_sauna_is_off() -> None:
+    """Test sauna switch reads OFF when register 57 is 0."""
+    desc = _description_for("sauna_function")
+    coordinator = _build_coordinator(_registers_with(57, 0))
+    entity = AirfiFunctionSwitch(coordinator, desc)
+
+    assert entity.is_on is False
+
+
+@pytest.mark.unit
+async def test_sauna_turn_on() -> None:
+    """Test turning on sauna writes 1 to register 57."""
+    entity = _build_switch("sauna_function", _registers_with(57, 0))
+
+    await entity.async_turn_on()
+
+    entity.coordinator.async_set_holding_register.assert_awaited_once_with(57, 1)
+    entity.coordinator.async_request_refresh.assert_awaited_once()
+    entity.async_write_ha_state.assert_called_once()
+
+
+@pytest.mark.unit
+async def test_sauna_turn_off() -> None:
+    """Test turning off sauna writes 0 to register 57."""
+    entity = _build_switch("sauna_function", _registers_with(57, 1))
+
+    await entity.async_turn_off()
+
+    entity.coordinator.async_set_holding_register.assert_awaited_once_with(57, 0)
+    entity.coordinator.async_request_refresh.assert_awaited_once()
+    entity.async_write_ha_state.assert_called_once()
+
+
+# ——— Boosted cooling tests ———
+
+
+@pytest.mark.unit
+def test_boosted_cooling_is_on() -> None:
+    """Test boosted cooling reads ON when register 51 is 1."""
+    desc = _description_for("boosted_cooling")
+    coordinator = _build_coordinator(_registers_with(51, 1))
+    entity = AirfiFunctionSwitch(coordinator, desc)
+
+    assert entity.is_on is True
+
+
+@pytest.mark.unit
+def test_boosted_cooling_is_off() -> None:
+    """Test boosted cooling reads OFF when register 51 is 0."""
+    desc = _description_for("boosted_cooling")
+    coordinator = _build_coordinator(_registers_with(51, 0))
+    entity = AirfiFunctionSwitch(coordinator, desc)
+
+    assert entity.is_on is False
+
+
+@pytest.mark.unit
+async def test_boosted_cooling_turn_on() -> None:
+    """Test turning on boosted cooling writes 1 to register 51."""
+    entity = _build_switch("boosted_cooling", _registers_with(51, 0))
+
+    await entity.async_turn_on()
+
+    entity.coordinator.async_set_holding_register.assert_awaited_once_with(51, 1)
+    entity.coordinator.async_request_refresh.assert_awaited_once()
+    entity.async_write_ha_state.assert_called_once()
+
+
+@pytest.mark.unit
+async def test_boosted_cooling_turn_off() -> None:
+    """Test turning off boosted cooling writes 0 to register 51."""
+    entity = _build_switch("boosted_cooling", _registers_with(51, 1))
+
+    await entity.async_turn_off()
+
+    entity.coordinator.async_set_holding_register.assert_awaited_once_with(51, 0)
+    entity.coordinator.async_request_refresh.assert_awaited_once()
+    entity.async_write_ha_state.assert_called_once()
+
+
+# ——— General tests ———
+
+
+@pytest.mark.unit
+def test_is_on_returns_none_when_register_missing() -> None:
+    """Test that is_on returns None when the register index is out of range."""
+    desc = _description_for("fireplace_function")
+    coordinator = _build_coordinator([0, 0])  # Only 2 registers
+    entity = AirfiFunctionSwitch(coordinator, desc)
+
+    assert entity.is_on is None
+
+
+@pytest.mark.unit
+def test_all_switches_disabled_by_default() -> None:
+    """Test that all switch descriptions have entity_registry_enabled_default=False."""
+    for desc in ENTITY_DESCRIPTIONS:
+        assert desc.entity_registry_enabled_default is False, f"{desc.key} should be disabled by default"
+
+
+@pytest.mark.unit
+async def test_optimistic_state_set_and_cleared() -> None:
+    """Test optimistic state is applied after write and cleared on coordinator update."""
+    entity = _build_switch("boosted_cooling", _registers_with(51, 0))
+
+    # After turn_on, optimistic state should be set and visible via is_on
+    await entity.async_turn_on()
+    assert entity._optimistic_state is True
+    assert entity.is_on is True
+    entity.async_write_ha_state.assert_called()
+
+    # Simulate coordinator update which should clear optimistic state
+    entity._handle_coordinator_update()
+    assert entity._optimistic_state is None
+
+
+@pytest.mark.unit
+def test_entity_description_feature_flags() -> None:
+    """Test that each switch description has the correct feature flag."""
+    expected = {
+        "fireplace_function": "fireplace_function",
+        "sauna_function": "sauna_function",
+        "boosted_cooling": "boosted_cooling",
+    }
+    for desc in ENTITY_DESCRIPTIONS:
+        assert desc.feature_flag == expected[desc.key]

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -11,6 +11,7 @@ from custom_components.airfi.data import AirfiData
 from custom_components.airfi.fan import async_setup_entry as fan_setup
 from custom_components.airfi.number import async_setup_entry as number_setup
 from custom_components.airfi.sensor import async_setup_entry as sensor_setup
+from custom_components.airfi.switch import async_setup_entry as switch_setup
 
 
 def _make_entry(hass, *, features: dict[str, bool] | None = None) -> MagicMock:
@@ -65,3 +66,28 @@ async def test_number_setup_entry_adds_entities(hass) -> None:
     added = []
     await number_setup(hass, entry, added.extend)
     assert len(added) >= 1
+
+
+@pytest.mark.unit
+async def test_switch_setup_entry_adds_entities_when_features_available(hass) -> None:
+    """Test that switch platform adds entities when features are supported."""
+    entry = _make_entry(
+        hass,
+        features={
+            "fireplace_function": True,
+            "sauna_function": True,
+            "boosted_cooling": True,
+        },
+    )
+    added = []
+    await switch_setup(hass, entry, added.extend)
+    assert len(added) == 3
+
+
+@pytest.mark.unit
+async def test_switch_setup_entry_adds_no_entities_when_features_unavailable(hass) -> None:
+    """Test that switch platform adds no entities when features are not supported."""
+    entry = _make_entry(hass, features={})
+    added = []
+    await switch_setup(hass, entry, added.extend)
+    assert len(added) == 0


### PR DESCRIPTION
## Description

This pull request introduces a new switch platform to the Airfi integration, adding support for feature-gated special function switches (fireplace, sauna, and boosted cooling) that are only available on devices with Modbus map version ≥ 2.5.0. The implementation includes new entity classes, register constants, icons, translations, documentation, and comprehensive tests to ensure correct feature gating and behavior.

**Switch platform and special function support:**

* Added a new `switch` platform, including `AirfiFunctionSwitch` entities for fireplace function, sauna function, and boosted cooling, each mapped to specific Modbus holding registers and feature flags. These switches use optimistic state updates and are only created if the device supports the corresponding feature. (`custom_components/airfi/switch/__init__.py`, `custom_components/airfi/switch/functions.py`, [[1]](diffhunk://#diff-a2d6d4ecebf7859f1b238124c7f193652f2bdf7f9c5e7d8f22bbb75eac956f2aR1-R101) [[2]](diffhunk://#diff-f0b47d9d85b970b8d71ebdc5c4deb7c86777ca468b74f5a8949647ed6350dfabR1-R35)
* Introduced constants for the Modbus holding register addresses for the new switches. (`custom_components/airfi/utils/switch.py`, [custom_components/airfi/utils/switch.pyR1-R24](diffhunk://#diff-f24d0de2cf213f795cd94526707e017e0df2acfe527557847ed35c22ed702665R1-R24))
* Updated the platform setup to include the switch platform. (`custom_components/airfi/__init__.py`, [custom_components/airfi/__init__.pyR39](diffhunk://#diff-3e98492243dcac51d46182a148d44422b4946a1372a9e22e7c5e147876650abfR39))

**Feature flag management and testing:**

* Extended the feature manager to gate the new switches on Modbus map version ≥ 2.5.0 and added/updated tests to verify correct feature flag behavior for all supported and unsupported versions. (`custom_components/airfi/coordinator/feature_manager.py`, `tests/coordinator/test_feature_manager.py`, [[1]](diffhunk://#diff-061f1a11cfd711977bcbf93a5747d46e139a2337315bc96dd724bfa3583d911eR38-R40) [[2]](diffhunk://#diff-2630b6c0193aa29e9bcb85d23f7fe8042789d53b645fa6c9ad3e3db737b75e30R83-R85) [[3]](diffhunk://#diff-2630b6c0193aa29e9bcb85d23f7fe8042789d53b645fa6c9ad3e3db737b75e30R105-R107) [[4]](diffhunk://#diff-2630b6c0193aa29e9bcb85d23f7fe8042789d53b645fa6c9ad3e3db737b75e30R117-R119) [[5]](diffhunk://#diff-2630b6c0193aa29e9bcb85d23f7fe8042789d53b645fa6c9ad3e3db737b75e30R129-R131) [[6]](diffhunk://#diff-2630b6c0193aa29e9bcb85d23f7fe8042789d53b645fa6c9ad3e3db737b75e30R141-R143) [[7]](diffhunk://#diff-2630b6c0193aa29e9bcb85d23f7fe8042789d53b645fa6c9ad3e3db737b75e30R153)

**User interface and experience:**

* Added appropriate icons for each new switch state. (`custom_components/airfi/icons.json`, [custom_components/airfi/icons.jsonR67-R86](diffhunk://#diff-07dbbb283016ef627f5cb05d31ef16f2a57a07cbc515fdb5cea84134aff83628R67-R86))
* Added translations for the new switches in English, Finnish, Polish, and Swedish. (`custom_components/airfi/translations/en.json`, [[1]](diffhunk://#diff-93b463d36f3bb5e85114df7eacf59f8c2a71215b34d22ab014baac2bf110e2b3R148-R158); `custom_components/airfi/translations/fi.json`, [[2]](diffhunk://#diff-e552df50ef59c3e62abd115a189927d6b1e68c9deaaa6939cbf102badf4cfbf1R148-R158); `custom_components/airfi/translations/pl.json`, [[3]](diffhunk://#diff-c9eceef556e16b8b43721af928442eea2c38523346aa46435ea2ab9d4a0ab836R148-R158); `custom_components/airfi/translations/sv.json`, [[4]](diffhunk://#diff-34a0ea22b76e77fde5a85e713aaac3f3206faeafe7f3caa2e17328b5a29b9bafR148-R158)

**Documentation updates:**

* Updated architecture and user documentation to describe the new switch platform, feature gating, register addresses, and user instructions for enabling the switches. (`docs/development/ARCHITECTURE.md`, [[1]](diffhunk://#diff-2817d8bbe6ebec58003d6cb387109c06e16213509289b1b146aefbd293211397R55-R57) [[2]](diffhunk://#diff-2817d8bbe6ebec58003d6cb387109c06e16213509289b1b146aefbd293211397L65-R69) [[3]](diffhunk://#diff-2817d8bbe6ebec58003d6cb387109c06e16213509289b1b146aefbd293211397L185-R191); `docs/user/CONFIGURATION.md`, [[4]](diffhunk://#diff-64c84e3922eb78f8000165740a323d6af33b430e7c219fe32458b638ebd0998bR103-R121)

**Test improvements:**

* Improved fan entity tests to verify that optimistic state updates and coordinator refreshes occur after register writes. (`tests/fan/test_fan.py`, [[1]](diffhunk://#diff-0b3bd7a70b485f07bd92b3453816a20516d3f5e16050526f27aedffe89cdf314R106-R108) [[2]](diffhunk://#diff-0b3bd7a70b485f07bd92b3453816a20516d3f5e16050526f27aedffe89cdf314R119-R121) [[3]](diffhunk://#diff-0b3bd7a70b485f07bd92b3453816a20516d3f5e16050526f27aedffe89cdf314R144-R146) [[4]](diffhunk://#diff-0b3bd7a70b485f07bd92b3453816a20516d3f5e16050526f27aedffe89cdf314R157-R158) [[5]](diffhunk://#diff-0b3bd7a70b485f07bd92b3453816a20516d3f5e16050526f27aedffe89cdf314R176-R177)

## Related Issue

Resolves #18

## Type of Change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvements

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] My code follows the code style of this project (run `script/lint`)
- [x] I have updated the documentation accordingly
- [x] I have updated the translations if needed
