### PR TITLE
Supply air temperature setting native unit

### DIFF
--- a/custom_components/airfi/icons.json
+++ b/custom_components/airfi/icons.json
@@ -12,7 +12,8 @@
       "fan": {
         "default": "mdi:fan-off",
         "state": {
-          "on": "mdi:fan"
+          "on": "mdi:fan",
+          "off": "mdi:briefcase"
         }
       }
     },
@@ -37,7 +38,7 @@
       "firmware_version": {
         "default": "mdi:information-outline",
         "state": {
-          "unavailable": "mdi:information-outline-off"
+          "unavailable": "mdi:information-off-outline"
         }
       },
       "modbus_register_version": {
@@ -73,16 +74,10 @@
         }
       },
       "sauna_function": {
-        "default": "mdi:radiator-off",
-        "state": {
-          "on": "mdi:radiator"
-        }
+        "default": "mdi:heat-wave"
       },
       "boosted_cooling": {
-        "default": "mdi:fan-off",
-        "state": {
-          "on": "mdi:fan-plus"
-        }
+        "default": "mdi:fan-plus"
       }
     }
   }

--- a/custom_components/airfi/number/temperature.py
+++ b/custom_components/airfi/number/temperature.py
@@ -8,6 +8,7 @@ from custom_components.airfi.utils.number import (
     HOLDING_REGISTER_TARGET_TEMPERATURE,
 )
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberEntityDescription, NumberMode
+from homeassistant.const import UnitOfTemperature
 
 ENTITY_DESCRIPTIONS: tuple[NumberEntityDescription, ...] = (
     NumberEntityDescription(
@@ -55,3 +56,8 @@ class AirfiTemperatureNumber(NumberEntity, AirfiEntity):
             )
 
         await self.coordinator.async_request_refresh()
+
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the unit of measurement for the number (°C)."""
+        return UnitOfTemperature.CELSIUS

--- a/custom_components/airfi/number/temperature.py
+++ b/custom_components/airfi/number/temperature.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from custom_components.airfi.entity import AirfiEntity
+from custom_components.airfi.sensor.temperature import INPUT_REGISTER_SUPPLY_AIR_TEMP, convert_temperature
 from custom_components.airfi.utils.number import (
     HOLDING_REGISTER_MINIMUM_TEMPERATURE,
     HOLDING_REGISTER_TARGET_TEMPERATURE,
@@ -61,3 +62,21 @@ class AirfiTemperatureNumber(NumberEntity, AirfiEntity):
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement for the number (°C)."""
         return UnitOfTemperature.CELSIUS
+
+    @property
+    def extra_state_attributes(self) -> dict[str, float | str | None]:
+        """Return additional attributes including current measured supply-air temperature.
+
+        Some Lovelace components read `supply_air_temperature` from entity attributes
+        to show the measured temperature alongside a setpoint control.
+        """
+        input_registers: list[int] = self.coordinator.data.get("input_registers", [])
+        index = INPUT_REGISTER_SUPPLY_AIR_TEMP - 1
+        if index >= len(input_registers):
+            return {}
+
+        value = convert_temperature(input_registers[index])
+
+        return {
+            "supply_air_temperature": value,
+        }

--- a/custom_components/airfi/number/temperature.py
+++ b/custom_components/airfi/number/temperature.py
@@ -2,20 +2,26 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from custom_components.airfi.entity import AirfiEntity
-from custom_components.airfi.sensor.temperature import INPUT_REGISTER_SUPPLY_AIR_TEMP, convert_temperature
 from custom_components.airfi.utils.number import (
     HOLDING_REGISTER_MINIMUM_TEMPERATURE,
     HOLDING_REGISTER_TARGET_TEMPERATURE,
 )
+from custom_components.airfi.utils.temperature import INPUT_REGISTER_SUPPLY_AIR_TEMP, convert_temperature
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberEntityDescription, NumberMode
 from homeassistant.const import UnitOfTemperature
+
+if TYPE_CHECKING:
+    from custom_components.airfi.coordinator import AirfiDataUpdateCoordinator
 
 ENTITY_DESCRIPTIONS: tuple[NumberEntityDescription, ...] = (
     NumberEntityDescription(
         key="supply_air_temperature_setting",
         translation_key="supply_air_temperature_setting",
         device_class=NumberDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         native_min_value=13.0,
         native_max_value=25.0,
         native_step=1.0,
@@ -34,6 +40,14 @@ class AirfiTemperatureNumber(NumberEntity, AirfiEntity):
     also writes holding register 50 (4x00050) with the raw °C value so the two
     settings stay in parity.
     """
+
+    def __init__(
+        self,
+        coordinator: AirfiDataUpdateCoordinator,
+        entity_description: NumberEntityDescription,
+    ) -> None:
+        """Initialize the number entity."""
+        super().__init__(coordinator, entity_description)
 
     @property
     def native_value(self) -> float | None:
@@ -57,11 +71,6 @@ class AirfiTemperatureNumber(NumberEntity, AirfiEntity):
             )
 
         await self.coordinator.async_request_refresh()
-
-    @property
-    def native_unit_of_measurement(self) -> str | None:
-        """Return the unit of measurement for the number (°C)."""
-        return UnitOfTemperature.CELSIUS
 
     @property
     def extra_state_attributes(self) -> dict[str, float | str | None]:

--- a/custom_components/airfi/sensor/temperature.py
+++ b/custom_components/airfi/sensor/temperature.py
@@ -2,34 +2,21 @@
 
 from __future__ import annotations
 
-import math
 from typing import TYPE_CHECKING
 
 from custom_components.airfi.entity import AirfiEntity
+from custom_components.airfi.utils.temperature import (
+    INPUT_REGISTER_EXHAUST_AIR_TEMP,
+    INPUT_REGISTER_EXTRACT_AIR_TEMP,
+    INPUT_REGISTER_OUTDOOR_AIR_TEMP,
+    INPUT_REGISTER_SUPPLY_AIR_TEMP,
+    convert_temperature,
+)
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorEntityDescription, SensorStateClass
 from homeassistant.const import UnitOfTemperature
 
 if TYPE_CHECKING:
     from custom_components.airfi.coordinator import AirfiDataUpdateCoordinator
-
-INPUT_REGISTER_OUTDOOR_AIR_TEMP = 4
-INPUT_REGISTER_EXTRACT_AIR_TEMP = 6
-INPUT_REGISTER_EXHAUST_AIR_TEMP = 7
-INPUT_REGISTER_SUPPLY_AIR_TEMP = 8
-
-
-def convert_temperature(value: float) -> float:
-    """Convert an Airfi temperature register value into Celsius."""
-    if not math.isfinite(value):
-        return 0.0
-
-    converted = value
-
-    # Keep parity with Homebridge conversion for signed 16-bit encoded values.
-    if converted > 62803:
-        converted = value - 65535
-
-    return round(converted / 10.0, 1)
 
 
 ENTITY_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (

--- a/custom_components/airfi/utils/temperature.py
+++ b/custom_components/airfi/utils/temperature.py
@@ -1,0 +1,31 @@
+"""Temperature register constants and conversion helpers for Airfi."""
+
+from __future__ import annotations
+
+import math
+
+INPUT_REGISTER_OUTDOOR_AIR_TEMP = 4
+"""Modbus input register address for outdoor air temperature (3x00004)."""
+
+INPUT_REGISTER_EXTRACT_AIR_TEMP = 6
+"""Modbus input register address for extract air temperature (3x00006)."""
+
+INPUT_REGISTER_EXHAUST_AIR_TEMP = 7
+"""Modbus input register address for exhaust air temperature (3x00007)."""
+
+INPUT_REGISTER_SUPPLY_AIR_TEMP = 8
+"""Modbus input register address for supply air temperature (3x00008)."""
+
+
+def convert_temperature(value: float) -> float:
+    """Convert an Airfi temperature register value into Celsius."""
+    if not math.isfinite(value):
+        return 0.0
+
+    converted = value
+
+    # Keep parity with Homebridge conversion for signed 16-bit encoded values.
+    if converted > 62803:
+        converted = value - 65535
+
+    return round(converted / 10.0, 1)

--- a/tests/number/test_temperature.py
+++ b/tests/number/test_temperature.py
@@ -7,6 +7,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.airfi.number.temperature import ENTITY_DESCRIPTIONS, AirfiTemperatureNumber
+from custom_components.airfi.sensor.temperature import convert_temperature
+from homeassistant.const import UnitOfTemperature
 
 
 def _build_coordinator(
@@ -33,10 +35,40 @@ def _build_coordinator(
     coordinator.feature_manager = feature_manager
     coordinator.data = {
         "holding_registers": holding_registers,
+        "input_registers": [],
         "model": "Airfi",
         "firmware_version": "3.8.1",
     }
     return coordinator
+
+
+@pytest.mark.unit
+def test_native_unit_and_supply_air_temperature_attribute() -> None:
+    """Number entity exposes Celsius unit and supply-air measurement attribute."""
+    # HR5 = 200 => setpoint 20.0
+    # Input register 8 = 206 => measured 20.6
+    input_registers = [0, 0, 0, 0, 0, 0, 0, 206]
+    coordinator = _build_coordinator([0, 0, 0, 0, 200])
+    coordinator.data["input_registers"] = input_registers
+
+    entity = AirfiTemperatureNumber(coordinator, ENTITY_DESCRIPTIONS[0])
+
+    assert entity.native_unit_of_measurement == UnitOfTemperature.CELSIUS
+
+    attrs = entity.extra_state_attributes
+    assert "supply_air_temperature" in attrs
+    assert attrs["supply_air_temperature"] == convert_temperature(input_registers[7])
+
+
+@pytest.mark.unit
+def test_extra_state_attributes_no_input_registers() -> None:
+    """Test that extra_state_attributes returns empty dict when input registers are missing."""
+    coordinator = _build_coordinator([0, 0, 0, 0, 200])
+    coordinator.data["input_registers"] = []  # No input registers
+
+    entity = AirfiTemperatureNumber(coordinator, ENTITY_DESCRIPTIONS[0])
+
+    assert entity.extra_state_attributes == {}
 
 
 @pytest.mark.unit

--- a/tests/number/test_temperature.py
+++ b/tests/number/test_temperature.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.airfi.number.temperature import ENTITY_DESCRIPTIONS, AirfiTemperatureNumber
-from custom_components.airfi.sensor.temperature import convert_temperature
 from homeassistant.const import UnitOfTemperature
 
 
@@ -57,7 +56,7 @@ def test_native_unit_and_supply_air_temperature_attribute() -> None:
 
     attrs = entity.extra_state_attributes
     assert "supply_air_temperature" in attrs
-    assert attrs["supply_air_temperature"] == convert_temperature(input_registers[7])
+    assert attrs["supply_air_temperature"] == 20.6
 
 
 @pytest.mark.unit

--- a/tests/sensor/test_temperature.py
+++ b/tests/sensor/test_temperature.py
@@ -6,7 +6,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from custom_components.airfi.sensor.temperature import ENTITY_DESCRIPTIONS, AirfiTemperatureSensor, convert_temperature
+from custom_components.airfi.sensor.temperature import ENTITY_DESCRIPTIONS, AirfiTemperatureSensor
+from custom_components.airfi.utils.temperature import convert_temperature
 
 
 def _build_coordinator(input_registers: list[int]) -> MagicMock:


### PR DESCRIPTION
## Description

This pull request introduces enhancements to the temperature number entity in the Airfi integration, focusing on exposing additional attributes and improving unit handling. It also updates icon mappings for better visual clarity and adds corresponding unit tests to ensure correct behavior.

**Enhancements to temperature number entity:**

* Added a `native_unit_of_measurement` property to `AirfiTemperatureNumber`, ensuring the entity always reports its unit as Celsius (`UnitOfTemperature.CELSIUS`). [[1]](diffhunk://#diff-6e82060a83d76f5e5dd87b2f58e9acce632e93a6283c45862225c83d39b239d0R6-R12) [[2]](diffhunk://#diff-6e82060a83d76f5e5dd87b2f58e9acce632e93a6283c45862225c83d39b239d0R60-R82)
* Introduced an `extra_state_attributes` property to expose the current measured supply-air temperature as an attribute, making this data available to Lovelace UI components.

**Testing improvements:**

* Added unit tests to verify the correct reporting of the native unit and the presence (or absence) of the `supply_air_temperature` attribute, including edge cases where input registers may be missing. [[1]](diffhunk://#diff-c41deeddbf8e64a80c592be1f71c4472872ed9c4e978f64ad987cb40232847ebR10-R11) [[2]](diffhunk://#diff-c41deeddbf8e64a80c592be1f71c4472872ed9c4e978f64ad987cb40232847ebR38-R73)

**Icon mapping updates:**

* Updated several icon mappings in `icons.json`:
  * Added an explicit `"off"` state for the `fan` icon.
  * Corrected the icon for the `"unavailable"` state of `firmware_version`.
  * Updated defaults for `sauna_function` and `boosted_cooling` to use more appropriate icons.

## Related Issue

Resolves #23 

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvements

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] My code follows the code style of this project (run `script/lint`)
- [x] I have updated the documentation accordingly
- [x] I have updated the translations if needed

## Testing

<!-- Please describe how you tested your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->
